### PR TITLE
Update Archive.java for a bug

### DIFF
--- a/src/main/java/de/innosystec/unrar/Archive.java
+++ b/src/main/java/de/innosystec/unrar/Archive.java
@@ -105,8 +105,8 @@ public class Archive implements Closeable {
      */
     public Archive(File file, UnrarCallback unrarCallback) throws RarException,
 	    IOException {
+        this.unrarCallback = unrarCallback;
 	setFile(file);
-	this.unrarCallback = unrarCallback;
 	dataIO = new ComprDataIO(this);
     }
 


### PR DESCRIPTION
the constructor of Archive(File file, UnrarCallback unrarCallback) , the second arg is evaluate to global variable unrarCallback after function setFile(File file) ,but the variable is used in the method setFile(File file) as a decide  condition